### PR TITLE
fix : Fixes the issue of layout breaking due to changes in layout priority in Hugo 0.146.0

### DIFF
--- a/.changeset/cool-badgers-leave.md
+++ b/.changeset/cool-badgers-leave.md
@@ -1,5 +1,5 @@
 ---
-"doks": patch
+"doks": minor
 ---
 
-Tiny typo "by by" => "by"
+fix : Fixes the issue of layout breaking due to changes in layout priority in Hugo 0.146.0

--- a/.changeset/cool-badgers-leave.md
+++ b/.changeset/cool-badgers-leave.md
@@ -1,5 +1,5 @@
 ---
-"doks": minor
+"doks": patch
 ---
 
-fix : Fixes the issue of layout breaking due to changes in layout priority in Hugo 0.146.0
+Tiny typo "by by" => "by"

--- a/.changeset/grumpy-ducks-divide.md
+++ b/.changeset/grumpy-ducks-divide.md
@@ -1,0 +1,5 @@
+---
+"doks": minor
+---
+
+fix : Fixes the issue of layout breaking due to changes in layout priority in Hugo 0.146.0

--- a/config/_default/hugo.toml
+++ b/config/_default/hugo.toml
@@ -8,7 +8,6 @@ enableEmoji = true
 enableGitInfo = false
 enableRobotsTXT = true
 languageCode = "en-US"
-paginate = 10
 rssLimit = 10
 summarylength = 20 # 70 (default)
 
@@ -63,6 +62,9 @@ copyRight = "Copyright (c) 2020-2024 Thulite"
 
 [minify.tdewolff.html]
   keepWhitespace = false
+
+[pagination]
+pagerSize = 10
 
 [related]
   threshold = 80

--- a/config/_default/module.toml
+++ b/config/_default/module.toml
@@ -54,6 +54,14 @@
 
 ## layouts
 [[mounts]]
+  source = "layouts"
+  target = "layouts"
+
+[[mounts]]
+  source = "node_modules/@thulite/doks-core/layouts"
+  target = "layouts"
+
+[[mounts]]
   source = "node_modules/@thulite/core/layouts"
   target = "layouts"
 
@@ -66,15 +74,7 @@
   target = "layouts"
 
 [[mounts]]
-  source = "node_modules/@thulite/doks-core/layouts"
-  target = "layouts"
-
-[[mounts]]
   source = "node_modules/@thulite/inline-svg/layouts"
-  target = "layouts"
-
-[[mounts]]
-  source = "layouts"
   target = "layouts"
 
 ## static

--- a/netlify.toml
+++ b/netlify.toml
@@ -5,7 +5,7 @@
 [build.environment]
   NODE_VERSION = "20.11.0"
   NPM_VERSION = "10.2.4"
-  HUGO_VERSION = "0.125.1"
+  HUGO_VERSION = "0.146.5"
 
 [context.production]
   command = "npm run build"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@tabler/icons": "^3.12.0",
-        "@thulite/doks-core": "^1.7.0",
+        "@thulite/doks-core": "^1.8.1",
         "@thulite/images": "^3.3.0",
         "@thulite/inline-svg": "^1.2.0",
         "@thulite/seo": "^2.4.0",
@@ -2864,9 +2864,10 @@
       }
     },
     "node_modules/@thulite/doks-core": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@thulite/doks-core/-/doks-core-1.7.0.tgz",
-      "integrity": "sha512-jTcYf6Y4SK77KiPcfRuOewYj4pcVZv5X35IcCETcxxYnagazfwSMuJw1x50PQ8yh3YdnwLD6E1iNzXzCX8pfbw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@thulite/doks-core/-/doks-core-1.8.1.tgz",
+      "integrity": "sha512-ALMrZD+pJ3V4K0wqw1SH9cNdwP7oEHhjXE1eemDi9wqcrGeoEzpVldBnFglbF7QoaEp/6rw8y3YDg/y+iGjmIw==",
+      "license": "MIT",
       "dependencies": {
         "@thulite/bootstrap": "^1.2.0",
         "clipboard": "^2.0.11",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "preview": "vite preview --outDir public"
   },
   "dependencies": {
-    "@thulite/doks-core": "^1.7.0",
+    "@thulite/doks-core": "^1.8.1",
     "@thulite/images": "^3.3.0",
     "@thulite/inline-svg": "^1.2.0",
     "@thulite/seo": "^2.4.0",


### PR DESCRIPTION
## Summary

In Hugo 0.146.0, the layout application priority has changed. ( See [Reimplement and simplify Hugo's template system #13541](https://github.com/gohugoio/hugo/pull/13541) )

This patch fixes an issue where the Doks theme is not rendered correctly with Hugo version 0.146.0 and above due to this change.

By applying this patch, the Doks theme will render properly on Hugo versions 0.146.0 and above.
However, please note that the theme will not render correctly on versions lower than 0.146.0 after applying this PR. Therefore, it is recommended to update Hugo to the latest version.

While it is technically possible to modify doks-core / @thuliteio/core to maintain compatibility with older versions, such changes would likely introduce significant side effects.
Additionally, since doks-core v1.8.1 already officially supports only Hugo 0.141.0 and above (See PR [layouts: use new try function #115](https://github.com/thuliteio/doks-core/pull/115), And my testing [Actions](https://github.com/LemonDouble/doks/actions/runs/14484393435)) retaining backward compatibility would not provide meaningful support for a wide range of Hugo versions.

As such, I think that it is appropriate to support only the latest Hugo version, 0.146.0 and above.

## Basic example

I checked this patch run on hugo's latest version.

![image](https://github.com/user-attachments/assets/c37cdd40-9410-46bd-841b-a4bbf3ebe838)
![image](https://github.com/user-attachments/assets/b297ccda-7113-434e-941b-33a891f66188)

## Motivation

See https://github.com/thuliteio/doks/issues/1355 

and it will close #1355 

## Checks

- [x] Read [Creating a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request)
- [x] Supports all screen sizes (if relevant)
- [x] Supports both light and dark mode (if relevant)
- [x] Passes `npm run test` (if relevant)
